### PR TITLE
[BC] Return empty array for uninitialized groups

### DIFF
--- a/src/Container.js
+++ b/src/Container.js
@@ -106,8 +106,7 @@ export default class Container {
             error;
         mapings = this._registrationGroups[groupName];
         if (!mapings) {
-            error = utils.sprintf('No group with name [%s] registered', groupName);
-            throw new Error(error);
+            return [];
         }
         for (let i = 0, len = mapings.length; i < len; i++) {
             items.push(this.resolve(mapings[i]));

--- a/tests/containerTests.js
+++ b/tests/containerTests.js
@@ -114,6 +114,11 @@ describe('Container', () =>  {
                 expect(B.isPrototypeOf(group[1])).toEqual(true);
             });
 
+            it('should return an empty array if no instance was registered for the group', () => {
+                var group = container.resolveGroup('emptyGroup');
+                expect(group.length).toBe(0);
+            });
+
             it('should throw if item already registered in group', () =>  {
                 var A = createObject();
                 expect(() => {


### PR DESCRIPTION
With the current behaviour when you try to resolve a group that hasn't been initialized, throws an exception.

This creates a code smell when you try to resolve the group while allowing no instances being registered. We have to do something like:
````
let recievedObjects = [];
try {
  receivedObjects = container.resolveGroup('myGroup');
} catch(ex) {}
````

As groups are not initialized explicitly, but are lazily created by RegistationModifiers (`inGroup`), it makes sense to just return an empty array when asking for a group that doesn't have any instance registered.