### PR TITLE
Added registerFactory function

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -33,6 +33,27 @@ You can register an object using one of two methods:
   It's [lifetime management](#lifetime-management) is `singletonPerContainer`.
   It can be resolved using the `identifier` or as part of the [group](#resolve-groups) `mySimilarObjects`. 
   
+* `container.registerFactory(identifier, factory)`.
+
+  This registers a factory using the given string `identifier`. The factory is a function that must return
+  the object instance which will be resolved. The factory will receive the current container as a first parameter.
+  This is a similar concept as using [Injection factories](#injection-factories) but perhaps a bit simpler.
+  
+    ```javascript
+    var identifier = 'itemKey1';
+    container
+      .registerFactory('identifier', (context, ...additionalDependencies) => {
+          console.log('This is called when trying to resolve `identifier`');
+          let scopedVar = 'scopedVar';
+          return new Item(
+            scopedVar,
+            context.resolve('otherDependencyIdentifier1')
+          );
+      })
+      .singletonPerContainer()
+      .inGroup('mySimilarObjects');
+    ```
+  
 * `container.registerInstance(identifier, objectInstance)`.
 
   Registers the given `objectInstance` using the string `identifier`.

--- a/jest.config
+++ b/jest.config
@@ -2,7 +2,7 @@
   "transform": {
     "^.+\\.js$": "<rootDir>/tests/__jest__/babelJest.js"
   },
-  "testRegex": "/tests/.*\\Tests\\.(js|ts)$",
+  "testRegex": "/tests/.*Tests\\.[jt]s$",
   "testResultsProcessor": "<rootDir>/node_modules/jest-teamcity-reporter",
   "moduleFileExtensions": [
     "ts",

--- a/microdi-js.d.ts
+++ b/microdi-js.d.ts
@@ -18,6 +18,7 @@ export class Container {
     createChildContainer():Container;
     register(name:String, proto:any):RegistrationModifier;
     registerInstance<T>(name:String, instance:T, isExternallyOwned?):void;
+    registerFactory<T>(name:String, factory:(context:Container, ...additionalDependencies:any[]) => T):RegistrationModifier;
     resolve<T>(name:String, ...additionalDependencies):T;
     resolveGroup(groupName:String):Array<any>;
     isRegistered(name : string) : boolean;

--- a/tests/containerTests.js
+++ b/tests/containerTests.js
@@ -34,6 +34,16 @@ describe('Container', () =>  {
             expect(foo.bar).toBe(5);
         });
 
+        it('should register/resolve an object with a custom factory', () =>  {
+            let Foo = createFunction({ bar: { value : 5 }});
+            container.registerFactory('foo', (context,...additionalDependencies) =>
+                new Foo(...additionalDependencies));
+            let foo = container.resolve('foo', 1, 2, 3);
+            expect(foo.bar).toBeDefined();
+            expect(foo.bar).toBe(5);
+            expect(foo.dependencies.length).toBe(3);
+        });
+
         it('should call init with resolving if object has init method', () =>  {
             let Foo = {
                 init: function() {
@@ -709,10 +719,11 @@ describe('Container', () =>  {
         return o;
     }
 
-    function createFunction() {
-        function AFunction() {
-            this.dependencies = Array.prototype.slice.call(arguments);
+    function createFunction(props) {
+        function AFunction(...dependencies) {
+            this.dependencies = dependencies;
         }
+        AFunction.prototype = createObject(props);
         return AFunction;
     }
 });


### PR DESCRIPTION
The aim of this is to allow registering dependencies in a type-safe manner in Typescript
So instead of 
```
container.register(ContainerConstants.random_type, RandomType)
    .inject(
        ContainerConstants.dependency1, 
        ContainerConstants.dependency2
    )
    .singleton();
```
We would have 
```
container.registerFactory<RandomType>(ContainerConstants.random_type, contextContainer =>
    new RandomType(
        contextContainer.resolve<DependencyType1>(ContainerConstants.dependency1),
        contextContainer.resolve<DependencyType2>(ContainerConstants.dependency2)
    ))
    .singleton();
```
So we will get transpile errors when we forget to inject some dependencies or if we change parameter ordering or types.